### PR TITLE
Adding CSS to toggle on/off suppression of duplicate page numbers in index entries.

### DIFF
--- a/pdf.css
+++ b/pdf.css
@@ -53,3 +53,12 @@ section[data-type="titlepage"] p.author {
   padding-left: 3in;
 }
 ----*/
+
+/* ----Uncomment to suppress duplicate page numbers in index entries
+       WARNING: MAY CAUSE PDF BUILDS TO SEGFAULT
+
+div[data-type="index"] {
+  -ah-suppress-duplicate-page-number: true;
+}
+
+----*/


### PR DESCRIPTION
Adding CSS to toggle on/off suppression of duplicate page numbers in index entries.

Production should use with caution, as it may introduce segfaults.