### PR TITLE
Updating "O'Reilly" section

### DIFF
--- a/docbook_only/preface.xml
+++ b/docbook_only/preface.xml
@@ -95,11 +95,11 @@
   </sect1>
 
   <sect1>
-       <title>O'Reilly</title>
+       <title>O'Reilly Online Learning</title>
 
     <note role="ormenabled">
       <para>For almost 40 years, <ulink role="orm:hideurl"
-      url="http://oreilly.com">O'Reilly</ulink> has provided technology and business training, knowledge, and insight to help companies succeed.</para>
+      url="http://oreilly.com">O'Reilly Media</ulink> has provided technology and business training, knowledge, and insight to help companies succeed.</para>
     </note>
 
     <para> Our unique network of experts and innovators share their knowledge and expertise through books, articles, conferences, and our online learning platform. O’Reilly’s online learning platform gives you on-demand access to live training courses, in-depth learning paths, interactive coding environments, and a vast collection of text and video from O'Reilly and 200+ other publishers. For more information, please visit <ulink role="orm:hideurl"


### PR DESCRIPTION
Changed "O'Reilly" header to "O'Reilly Online Learning" and the linked "O'Reilly" in the text to "O'Reilly Media"