### PR TITLE
Add uuid and title to jupter formal example

### DIFF
--- a/jupyter_book_only/sample_chapter.ipynb
+++ b/jupyter_book_only/sample_chapter.ipynb
@@ -73,6 +73,9 @@
    },
    "outputs": [],
    "source": [
+    "# example_uuid\n",
+    "# Put the example title in the second comment\n",
+    "\n",
     "def my_example_func():\n",
     "    return \"This is an example!\""
    ]


### PR DESCRIPTION
I forgot to include the UUID and Title comments in the example -- this commit adds them!