### PR TITLE
Minor formatting changes to URLS in preface files

### DIFF
--- a/asciidoc_only/preface.asciidoc
+++ b/asciidoc_only/preface.asciidoc
@@ -71,7 +71,7 @@ Please address comments and questions concerning this book to the publisher:
 </ul>
 ++++
 
-We have a web page for this book, where we list errata, examples, and any additional information. You can access this page at link:$$https://www.oreilly.com/catalog/<catalog page>$$[].
+We have a web page for this book, where we list errata, examples, and any additional information. You can access this page at link:$$https://www.oreilly.com/catalog/catalog_page$$[].
 
 ++++
 <!--Don't forget to update the link above.-->

--- a/docbook_only/preface.xml
+++ b/docbook_only/preface.xml
@@ -149,7 +149,7 @@
     url="https://twitter.com/oreillymedia"></ulink></para>
 
     <para>Watch us on YouTube: <ulink
-    url="https://www.youtube.com/oreillymedia"></ulink></para>
+    url="https://youtube.com/oreillymedia"></ulink></para>
   </sect1>
 
   <sect1>

--- a/htmlbook_only/preface.html
+++ b/htmlbook_only/preface.html
@@ -60,7 +60,7 @@
   <li><a class="email" href="mailto:support@oreilly.com"><em>support@oreilly.com</em></a></li>
   <li><a href="https://www.oreilly.com/about/contact.html"><em>https://www.oreilly.com/about/contact.html</em></a></li>
 </ul>
-<p>We have a web page for this book, where we list errata, examples, and any additional information. You can access this page at <a href="https://www.oreilly.com/catalog/&lt;catalog page&gt;">https://www.oreilly.com/catalog/&lt;catalog page&gt;</a>.</p>
+<p>We have a web page for this book, where we list errata, examples, and any additional information. You can access this page at <a href="https://www.oreilly.com/catalog/catalog_page">https://www.oreilly.com/catalog/&lt;catalog page&gt;</a>.</p>
 <!--Don't forget to update the link above.-->
 
 <p>For news and information about our books and courses, visit <a href="https://oreilly.com">https://oreilly.com</a>.</p>


### PR DESCRIPTION
Changed the formatting of the placeholder catalog page in the adoc and html preface files (the current/old format causes EPUB errors). And removed the 'www' from the youtube URL in the docbook preface file.