### PR TITLE
updating linkedin URL and removing ital from Oreilly Media

### DIFF
--- a/asciidoc_only/preface.asciidoc
+++ b/asciidoc_only/preface.asciidoc
@@ -49,7 +49,7 @@ If you feel your use of code examples falls outside fair use or the permission g
 [role = "ormenabled"]
 [NOTE]
 ====
-For more than 40 years, pass:[<a href="https://oreilly.com" class="orm:hideurl"><em class="hyperlink">O’Reilly Media</em></a>] has provided technology and business training, knowledge, and insight to help companies succeed.
+For more than 40 years, pass:[<a href="https://oreilly.com" class="orm:hideurl">O’Reilly Media</a>] has provided technology and business training, knowledge, and insight to help companies succeed.
 ====
 
 Our unique network of experts and innovators share their knowledge and expertise through books, articles, and our online learning platform. O’Reilly’s online learning platform gives you on-demand access to live training courses, in-depth learning paths, interactive coding environments, and a vast collection of text and video from O'Reilly and 200+ other publishers. For more information, visit pass:[<a href="https://oreilly.com" class="orm:hideurl"><em>https://oreilly.com</em></a>].
@@ -79,7 +79,7 @@ We have a web page for this book, where we list errata, examples, and any additi
 
 For news and information about our books and courses, visit link:$$https://oreilly.com$$[].
 
-Find us on LinkedIn: link:$$https://linkedin.com/company/oreilly-media$$[]
+Find us on LinkedIn: link:$$https://linkedin.com/company/oreilly$$[]
 
 Follow us on Twitter: link:$$https://twitter.com/oreillymedia$$[]
 

--- a/asciidoc_only/preface_make.asciidoc
+++ b/asciidoc_only/preface_make.asciidoc
@@ -49,7 +49,7 @@ If you feel your use of code examples falls outside fair use or the permission g
 [role = "ormenabled"]
 [NOTE]
 ====
-For more than 40 years, pass:[<a href="https://oreilly.com" class="orm:hideurl"><em class="hyperlink">O’Reilly Media</em></a>] has provided technology and business training, knowledge, and insight to help companies succeed.
+For more than 40 years, pass:[<a href="https://oreilly.com" class="orm:hideurl">O’Reilly Media</a>] has provided technology and business training, knowledge, and insight to help companies succeed.
 ====
 
 Our unique network of experts and innovators share their knowledge and expertise through books, articles, conferences, and our online learning platform. O’Reilly’s online learning platform gives you on-demand access to live training courses, in-depth learning paths, interactive coding environments, and a vast collection of text and video from O'Reilly and 200+ other publishers. For more information, please visit pass:[<a href="https://oreilly.com" class="orm:hideurl"><em>https://oreilly.com</em></a>].

--- a/docbook_only/preface.xml
+++ b/docbook_only/preface.xml
@@ -143,7 +143,7 @@
     url="http://oreilly.com"></ulink>.</para>
 
     <para>Find us on LinkedIn: <ulink
-    url="https://linkedin.com/company/oreilly-media"></ulink></para>
+    url="https://linkedin.com/company/oreilly"></ulink></para>
 
     <para>Follow us on Twitter: <ulink
     url="https://twitter.com/oreillymedia"></ulink></para>

--- a/htmlbook_only/preface.html
+++ b/htmlbook_only/preface.html
@@ -43,7 +43,7 @@
 <section data-type="sect1" id="_safari_books_online">
 <h1>O'Reilly Online Learning</h1>
 <div data-type="note" class="ormenabled">
-<p>For more than 40 years, <a xmlns="http://www.w3.org/1999/xhtml" href="https://oreilly.com" class="orm:hideurl"><em class="hyperlink">O'Reilly Media</em></a> has provided technology and business training, knowledge, and insight to help companies succeed.</p>
+<p>For more than 40 years, <a xmlns="http://www.w3.org/1999/xhtml" href="https://oreilly.com" class="orm:hideurl">O'Reilly Media</a> has provided technology and business training, knowledge, and insight to help companies succeed.</p>
 </div>
 <p>Our unique network of experts and innovators share their knowledge and expertise through books, articles, and our online learning platform. O’Reilly’s online learning platform gives you on-demand access to live training courses, in-depth learning paths, interactive coding environments, and a vast collection of text and video from O'Reilly and 200+ other publishers. For more information, visit <a xmlns="http://www.w3.org/1999/xhtml" href="https://oreilly.com" class="orm:hideurl"><em>https://oreilly.com</em></a>.</p>
 </section>
@@ -64,7 +64,7 @@
 <!--Don't forget to update the link above.-->
 
 <p>For news and information about our books and courses, visit <a href="https://oreilly.com">https://oreilly.com</a>.</p>
-<p>Find us on LinkedIn: <a href="https://linkedin.com/company/oreilly-media">https://linkedin.com/company/oreilly-media</a></p>
+<p>Find us on LinkedIn: <a href="https://linkedin.com/company/oreilly">https://linkedin.com/company/oreilly</a></p>
 <p>Follow us on Twitter: <a href="https://twitter.com/oreillymedia">https://twitter.com/oreillymedia</a></p>
 <p>Watch us on YouTube: <a href="https://youtube.com/oreillymedia">https://youtube.com/oreillymedia</a></p>
 </section>

--- a/htmlbook_only/preface_make.html
+++ b/htmlbook_only/preface_make.html
@@ -43,7 +43,7 @@
 <section data-type="sect1" id="_safari_books_online">
 <h1>O'Reilly Online Learning</h1>
 <div data-type="note" class="ormenabled">
-<p>For more than 40 years, <a xmlns="http://www.w3.org/1999/xhtml" href="https://oreilly.com" class="orm:hideurl"><em class="hyperlink">O'Reilly Media</em></a> has provided technology and business training, knowledge, and insight to help companies succeed.</p>
+<p>For more than 40 years, <a xmlns="http://www.w3.org/1999/xhtml" href="https://oreilly.com" class="orm:hideurl">O'Reilly Media</a> has provided technology and business training, knowledge, and insight to help companies succeed.</p>
 </div>
 <p>Our unique network of experts and innovators share their knowledge and expertise through books, articles, conferences, and our online learning platform. O’Reilly’s online learning platform gives you on-demand access to live training courses, in-depth learning paths, interactive coding environments, and a vast collection of text and video from O'Reilly and 200+ other publishers. For more information, please visit <a xmlns="http://www.w3.org/1999/xhtml" href="https://www.oreilly.com" class="orm:hideurl"><em>https://oreilly.com</em></a>.</p>
 </section>

--- a/jupyter_book_only/preface.ipynb
+++ b/jupyter_book_only/preface.ipynb
@@ -9,6 +9,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
@@ -59,7 +70,7 @@
     "## O'Reilly Online Learning\n",
     "\n",
     "<div data-type=\"note\" class=\"ormenabled\">\n",
-    "<p>For more than 40 years, <a xmlns=\"http://www.w3.org/1999/xhtml\" href=\"https://oreilly.com\" class=\"orm:hideurl\"><em class=\"hyperlink\">O'Reilly Media</em></a> has provided technology and business training, knowledge, and insight to help companies succeed.</p>\n",
+    "<p>For more than 40 years, <a xmlns=\"http://www.w3.org/1999/xhtml\" href=\"https://oreilly.com\" class=\"orm:hideurl\">O'Reilly Media</a> has provided technology and business training, knowledge, and insight to help companies succeed.</p>\n",
     "</div>\n",
     "\n",
     "Our unique network of experts and innovators share their knowledge and expertise through books, articles, and our online learning platform. O’Reilly’s online learning platform gives you on-demand access to live training courses, in-depth learning paths, interactive coding environments, and a vast collection of text and video from O'Reilly and 200+ other publishers. For more information, visit <a href=\"https://oreilly.com\" class=\"orm:hideurl\"><em>https://oreilly.com</em></a>.\n",
@@ -85,9 +96,7 @@
     "\n",
     "For news and information about our books and courses, visit [https://oreilly.com](https://oreilly.com).\n",
     "\n",
-    "Find us on LinkedIn: [https://linkedin.com/company/oreilly-media](https://linkedin.com/company/oreilly-media).\n",
-    "\n",
-    "Follow us on Twitter: [https://twitter.com/oreillymedia](https://twitter.com/oreillymedia).\n",
+    "Find us on LinkedIn: [https://linkedin.com/company/oreilly](https://linkedin.com/company/oreilly).\n",
     "\n",
     "Watch us on YouTube: [https://youtube.com/oreillymedia](https://youtube.com/oreillymedia).\n",
     "\n",


### PR DESCRIPTION
Updated all preface files to remove italics from "O'Reilly Media" and removed the "-media" from the LinkedIn URL.