### PR TITLE
add default alt text to cover.html img elem

### DIFF
--- a/cover.html
+++ b/cover.html
@@ -1,3 +1,3 @@
 <figure data-type="cover">
-  <img src="images/cover.png"/>
+  <img src="images/cover.png" alt="The cover of this book"/>
 </figure>


### PR DESCRIPTION
Default alt text for cover.html image that in practice will be overwritten during the alt-text generation process.