### PR TITLE
TOOLSDEV-569: replace static lang value with atlas.json field value in layout.html

### DIFF
--- a/layout.html
+++ b/layout.html
@@ -1,5 +1,5 @@
 {{ doctype }}
-<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<html lang="{{ lang }}" xmlns="http://www.w3.org/1999/xhtml">
   <head>
     <meta charset="utf-8" />
     <meta name="publisher" content="O'Reilly Media, Inc."/>


### PR DESCRIPTION
This update will enable theme localization in EPUBs, for parity with PDF builds, and allow ebook accessibility attributes (lang and xml:lang declarations) to sync with atlas.json language field setting.

In the event that atlas.json has no lang field, the htmlbook param default ensures language will fall back to 'en' in the EPUB output.

Tested on Atlas staging.